### PR TITLE
fix(2.7.1): 小米 AI 接入兼容 + 前端恢复路由首屏鉴权修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ tmpclaude-*/
 # 本机打包记录（独属于当前打包服务器，不纳入版本管理）
 version-history.csv
 versions.json
+
+# Understand-Anything 知识图谱产物（本地分析用，不纳入版本管理）
+.understand-anything/

--- a/Web/ydjz_web_v2/src/desktop/router.ts
+++ b/Web/ydjz_web_v2/src/desktop/router.ts
@@ -62,15 +62,21 @@ const PUBLIC_PATHS = ['/auth', '/api-test']
  * 解决“恢复上次路由”首屏卡死的问题：
  * - 重新打开网页会恢复到上次的深层路由（浏览器原生 URL 恢复）
  * - 若此时本地没有 token（会话已失效），不应先渲染陈旧页面再等接口 401 才跳转，
- *   而是直接、干净地跳到登录页 —— 避免“看得见但点不动、必须刷新+重登”的卡死态。
+ *   而是直接、干净地跳到 /auth —— 避免“看得见但点不动、必须刷新+重登”的卡死态。
+ *
+ * 关键：守卫只负责“无 token 时干净跳到 /auth”，**不决定 登录/注册 模式**。
+ * 模式只能由后端判定（secret.key 是否存在 → 401 登录 / 418 注册），
+ * 因此这里不带 mode，交由 Auth.vue 挂载时探测后端信号再定。
+ * （旧实现写死 mode=1 会让全新部署的首装用户错误地看到登录页而非注册页。）
  */
 router.beforeEach((to) => {
-  const isPublic = PUBLIC_PATHS.some((p) => to.path.startsWith(p))
+  // 整段匹配，避免 /authorize、/api-test-xxx 这类需登录路由被前缀误放行
+  const isPublic = PUBLIC_PATHS.some((p) => to.path === p || to.path.startsWith(p + '/'))
   const hasToken = !!localStorage.getItem('token')
 
-  // 需要登录但没有 token -> 跳登录页（携带原始目标，登录后回跳）
+  // 需要登录但没有 token -> 跳 /auth（携带原始目标，登录后回跳；mode 由 Auth.vue 探测决定）
   if (!isPublic && !hasToken) {
-    return { path: '/auth', query: { redirect: to.fullPath, mode: '1' }, replace: true }
+    return { path: '/auth', query: { redirect: to.fullPath }, replace: true }
   }
 
   return true

--- a/Web/ydjz_web_v2/src/desktop/router.ts
+++ b/Web/ydjz_web_v2/src/desktop/router.ts
@@ -53,4 +53,27 @@ const router = createRouter({
   routes,
 })
 
+// 无需登录即可访问的白名单路由
+const PUBLIC_PATHS = ['/auth', '/api-test']
+
+/**
+ * 路由前置守卫：鉴权
+ *
+ * 解决“恢复上次路由”首屏卡死的问题：
+ * - 重新打开网页会恢复到上次的深层路由（浏览器原生 URL 恢复）
+ * - 若此时本地没有 token（会话已失效），不应先渲染陈旧页面再等接口 401 才跳转，
+ *   而是直接、干净地跳到登录页 —— 避免“看得见但点不动、必须刷新+重登”的卡死态。
+ */
+router.beforeEach((to) => {
+  const isPublic = PUBLIC_PATHS.some((p) => to.path.startsWith(p))
+  const hasToken = !!localStorage.getItem('token')
+
+  // 需要登录但没有 token -> 跳登录页（携带原始目标，登录后回跳）
+  if (!isPublic && !hasToken) {
+    return { path: '/auth', query: { redirect: to.fullPath, mode: '1' }, replace: true }
+  }
+
+  return true
+})
+
 export default router

--- a/Web/ydjz_web_v2/src/desktop/views/Auth.vue
+++ b/Web/ydjz_web_v2/src/desktop/views/Auth.vue
@@ -78,7 +78,10 @@ async function onSubmit() {
     ElMessage.success(isLogin.value ? '登录成功' : '注册成功')
 
     // 跳转（使用 replace，不让登录页留在历史记录中）
-    const redirect = (route.query.redirect as string) || '/'
+    // 净化 redirect：避免 redirect 指向 /auth（会话失效时可能被污染成
+    // /auth?redirect=... 嵌套），否则登录成功后又跳回登录页 → 看似登录失败
+    const rawRedirect = (route.query.redirect as string) || ''
+    const redirect = rawRedirect && !rawRedirect.startsWith('/auth') ? rawRedirect : '/'
     router.replace(redirect)
   } catch (err: any) {
     // 418：登录时用户不存在 → 引导切换到注册模式

--- a/Web/ydjz_web_v2/src/desktop/views/Auth.vue
+++ b/Web/ydjz_web_v2/src/desktop/views/Auth.vue
@@ -1,20 +1,63 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox, ElLoading } from 'element-plus'
 import { User, Lock } from '@element-plus/icons-vue'
 import MD5 from 'crypto-js/md5'
 import { authApi } from '@shared/api/auth'
+import { homeApi } from '@shared/api/home'
 import { ApiCode } from '@shared/types'
 import logoUrl from '@shared/assets/logo.png'
 
 const route = useRoute()
 const router = useRouter()
 
-// 单用户系统：mode 由 API 拦截器决定
+// 解析登录/注册后的回跳目标：
+// - query 同名多值时 route.query.redirect 运行时是数组，强转 string 调 .startsWith 会抛 TypeError，
+//   先收敛为单值；
+// - 避免 redirect 指向 /auth（会话失效时可能被污染成 /auth?redirect=... 嵌套），否则登录后又跳回登录页。
+function resolveRedirect(fallback: string): string {
+  const raw = route.query.redirect
+  const value = Array.isArray(raw) ? raw[0] : raw
+  return value && !value.startsWith('/auth') ? value : fallback
+}
+
+// 单用户系统：mode 由后端判定（secret.key 是否存在 → 401 登录 / 418 注册）
 // mode=0 未注册 → 注册页
 // mode=1 未登录 → 登录页
+// 未带 mode（守卫无 token 跳来）→ 默认按登录展示，onMounted 探测后端后再校正
 const isLogin = computed(() => route.query.mode !== '0')
+
+/**
+ * 探测后端真实状态，决定 登录/注册 模式。
+ *
+ * 背景：路由守卫无 token 时只“干净跳到 /auth”，不写死 mode（写死 mode=1 会让
+ * 全新部署的首装用户错看到登录页）。唯一能区分“首装 vs 已有用户”的是后端：
+ * 无 token 请求任意业务接口，后端按 secret.key 是否存在返回 401（已有用户→登录）
+ * 或 418（尚无用户→注册）。这里复用现成只读接口 /home/getVersion 探测，不新增后端契约。
+ *
+ * - 418 → 注册模式（mode=0）
+ * - 接口成功（后端关闭了登录）→ 直接进入应用
+ * - 其他（401 / 网络错误）→ 登录模式（mode=1）：对“已有用户”是正确缺省
+ *
+ * 注意：探测请求触发的 onUnauthorized 因当前已在 /auth 而不会再跳转（见 main-*.ts 守卫），
+ * 故不会与本逻辑互相干扰。
+ */
+async function detectMode() {
+  // URL 已明确带 mode（如登录失败后切到 mode=0）→ 尊重之，不再探测
+  if (route.query.mode === '0' || route.query.mode === '1') return
+
+  try {
+    await homeApi.getSystemConfig()
+    // 探测成功：后端未开启登录鉴权，无需停留登录页，直接进入应用
+    router.replace(resolveRedirect('/'))
+  } catch (err: any) {
+    // 418 未注册 → 注册模式；其余（401/网络错误）→ 登录模式
+    const mode = err?.code === ApiCode.NOT_REGISTERED ? '0' : '1'
+    router.replace({ path: '/auth', query: { ...route.query, mode } })
+  }
+}
+
 const title = computed(() => isLogin.value ? '欢迎回来' : '创建账户')
 const subtitle = computed(() => isLogin.value ? '请登录您的账户' : '首次使用，请设置账户')
 const buttonText = computed(() => isLogin.value ? '登录' : '注册')
@@ -22,6 +65,8 @@ const buttonText = computed(() => isLogin.value ? '登录' : '注册')
 const username = ref('')
 const password = ref('')
 const loading = ref(false)
+
+onMounted(detectMode)
 
 // 表单验证
 function validate(): string | null {
@@ -78,11 +123,7 @@ async function onSubmit() {
     ElMessage.success(isLogin.value ? '登录成功' : '注册成功')
 
     // 跳转（使用 replace，不让登录页留在历史记录中）
-    // 净化 redirect：避免 redirect 指向 /auth（会话失效时可能被污染成
-    // /auth?redirect=... 嵌套），否则登录成功后又跳回登录页 → 看似登录失败
-    const rawRedirect = (route.query.redirect as string) || ''
-    const redirect = rawRedirect && !rawRedirect.startsWith('/auth') ? rawRedirect : '/'
-    router.replace(redirect)
+    router.replace(resolveRedirect('/'))
   } catch (err: any) {
     // 418：登录时用户不存在 → 引导切换到注册模式
     if (err?.code === ApiCode.NOT_REGISTERED && isLogin.value) {

--- a/Web/ydjz_web_v2/src/main-mobile.ts
+++ b/Web/ydjz_web_v2/src/main-mobile.ts
@@ -14,7 +14,17 @@ import { ApiCode } from '@shared/types'
 setupRequest({
   baseURL: window.config?.apiBaseUrl || '/api',
   onUnauthorized: (code) => {
-    const redirect = router.currentRoute.value.fullPath
+    const current = router.currentRoute.value
+
+    // 已在登录页：不重复跳转。
+    // 否则会话失效时首屏并发的多个 401 会把 /auth?redirect=... 整段
+    // 再次当作 redirect 层层嵌套，产生畸形 URL（登录后回不去）。
+    if (current.path.startsWith('/auth')) {
+      return
+    }
+
+    // 仅记录“真实业务页面”作为登录后回跳目标
+    const redirect = current.fullPath
 
     // 未注册 -> 注册模式（使用 replace，不留历史记录）
     if (code === ApiCode.NOT_REGISTERED) {

--- a/Web/ydjz_web_v2/src/mobile/router.ts
+++ b/Web/ydjz_web_v2/src/mobile/router.ts
@@ -246,6 +246,30 @@ const router = createRouter({
   routes,
 })
 
+// 无需登录即可访问的白名单路由
+const PUBLIC_PATHS = ['/auth']
+
+/**
+ * 路由前置守卫：鉴权
+ *
+ * 解决“恢复上次路由”首屏卡死的问题：
+ * - 重新打开网页会恢复到上次的深层路由（浏览器原生 URL 恢复）
+ * - 若此时本地没有 token（会话已失效），不应先渲染陈旧页面再等接口 401 才跳转，
+ *   而是直接、干净地跳到登录页 —— 避免“看得见但点不动、必须刷新+重登”的卡死态，
+ *   也避免首屏并发 401 把 /auth?redirect=... 层层嵌套成畸形 URL。
+ */
+router.beforeEach((to) => {
+  const isPublic = PUBLIC_PATHS.some((p) => to.path.startsWith(p))
+  const hasToken = !!localStorage.getItem('token')
+
+  // 需要登录但没有 token -> 跳登录页（携带原始目标，登录后回跳）
+  if (!isPublic && !hasToken) {
+    return { path: '/auth', query: { redirect: to.fullPath, mode: '1' }, replace: true }
+  }
+
+  return true
+})
+
 // 路由后置守卫：记录路由历史
 router.afterEach((to) => {
   // 延迟获取 store，确保 pinia 已初始化

--- a/Web/ydjz_web_v2/src/mobile/router.ts
+++ b/Web/ydjz_web_v2/src/mobile/router.ts
@@ -255,16 +255,22 @@ const PUBLIC_PATHS = ['/auth']
  * 解决“恢复上次路由”首屏卡死的问题：
  * - 重新打开网页会恢复到上次的深层路由（浏览器原生 URL 恢复）
  * - 若此时本地没有 token（会话已失效），不应先渲染陈旧页面再等接口 401 才跳转，
- *   而是直接、干净地跳到登录页 —— 避免“看得见但点不动、必须刷新+重登”的卡死态，
+ *   而是直接、干净地跳到 /auth —— 避免“看得见但点不动、必须刷新+重登”的卡死态，
  *   也避免首屏并发 401 把 /auth?redirect=... 层层嵌套成畸形 URL。
+ *
+ * 关键：守卫只负责“无 token 时干净跳到 /auth”，**不决定 登录/注册 模式**。
+ * 模式只能由后端判定（secret.key 是否存在 → 401 登录 / 418 注册），
+ * 因此这里不带 mode，交由 Auth.vue 挂载时探测后端信号再定。
+ * （旧实现写死 mode=1 会让全新部署的首装用户错误地看到登录页而非注册页。）
  */
 router.beforeEach((to) => {
-  const isPublic = PUBLIC_PATHS.some((p) => to.path.startsWith(p))
+  // 整段匹配，避免 /authorize、/api-test-xxx 这类需登录路由被前缀误放行
+  const isPublic = PUBLIC_PATHS.some((p) => to.path === p || to.path.startsWith(p + '/'))
   const hasToken = !!localStorage.getItem('token')
 
-  // 需要登录但没有 token -> 跳登录页（携带原始目标，登录后回跳）
+  // 需要登录但没有 token -> 跳 /auth（携带原始目标，登录后回跳；mode 由 Auth.vue 探测决定）
   if (!isPublic && !hasToken) {
-    return { path: '/auth', query: { redirect: to.fullPath, mode: '1' }, replace: true }
+    return { path: '/auth', query: { redirect: to.fullPath }, replace: true }
   }
 
   return true

--- a/Web/ydjz_web_v2/src/mobile/views/Auth.vue
+++ b/Web/ydjz_web_v2/src/mobile/views/Auth.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { showDialog, showLoadingToast, closeToast, showToast } from 'vant'
 import MD5 from 'crypto-js/md5'
 import { authApi } from '@shared/api/auth'
+import { homeApi } from '@shared/api/home'
 import { ApiCode } from '@shared/types'
 import { useThemeStore } from '@shared/stores/theme'
 import logoUrl from '@shared/assets/logo.png'
@@ -12,10 +13,52 @@ const route = useRoute()
 const router = useRouter()
 const themeStore = useThemeStore()
 
-// 单用户系统：mode 由 API 拦截器决定
+// 解析登录/注册后的回跳目标：
+// - query 同名多值时 route.query.redirect 运行时是数组，强转 string 调 .startsWith 会抛 TypeError，
+//   先收敛为单值；
+// - 避免 redirect 指向 /auth（会话失效时可能被污染成 /auth?redirect=... 嵌套），否则登录后又跳回登录页。
+function resolveRedirect(fallback: string): string {
+  const raw = route.query.redirect
+  const value = Array.isArray(raw) ? raw[0] : raw
+  return value && !value.startsWith('/auth') ? value : fallback
+}
+
+// 单用户系统：mode 由后端判定（secret.key 是否存在 → 401 登录 / 418 注册）
 // mode=0 未注册 → 注册页
 // mode=1 未登录 → 登录页
+// 未带 mode（守卫无 token 跳来）→ 默认按登录展示，onMounted 探测后端后再校正
 const isLogin = computed(() => route.query.mode !== '0')
+
+/**
+ * 探测后端真实状态，决定 登录/注册 模式。
+ *
+ * 背景：路由守卫无 token 时只“干净跳到 /auth”，不写死 mode（写死 mode=1 会让
+ * 全新部署的首装用户错看到登录页）。唯一能区分“首装 vs 已有用户”的是后端：
+ * 无 token 请求任意业务接口，后端按 secret.key 是否存在返回 401（已有用户→登录）
+ * 或 418（尚无用户→注册）。这里复用现成只读接口 /home/getVersion 探测，不新增后端契约。
+ *
+ * - 418 → 注册模式（mode=0）
+ * - 接口成功（后端关闭了登录）→ 直接进入应用
+ * - 其他（401 / 网络错误）→ 登录模式（mode=1）：对“已有用户”是正确缺省
+ *
+ * 注意：探测请求触发的 onUnauthorized 因当前已在 /auth 而不会再跳转（见 main-*.ts 守卫），
+ * 故不会与本逻辑互相干扰。
+ */
+async function detectMode() {
+  // URL 已明确带 mode（如登录失败后切到 mode=0）→ 尊重之，不再探测
+  if (route.query.mode === '0' || route.query.mode === '1') return
+
+  try {
+    await homeApi.getSystemConfig()
+    // 探测成功：后端未开启登录鉴权，无需停留登录页，直接进入应用
+    router.replace(resolveRedirect('/board'))
+  } catch (err: any) {
+    // 418 未注册 → 注册模式；其余（401/网络错误）→ 登录模式
+    const mode = err?.code === ApiCode.NOT_REGISTERED ? '0' : '1'
+    router.replace({ path: '/auth', query: { ...route.query, mode } })
+  }
+}
+
 const title = computed(() => isLogin.value ? '欢迎回来' : '创建账户')
 const subtitle = computed(() => isLogin.value ? '请登录您的账户' : '首次使用，请设置账户')
 const buttonText = computed(() => isLogin.value ? '登录' : '注册')
@@ -26,6 +69,8 @@ const loading = ref(false)
 
 // password autocomplete：登录用 current-password，注册用 new-password
 const passwordAutocomplete = computed(() => isLogin.value ? 'current-password' : 'new-password')
+
+onMounted(detectMode)
 
 // 表单验证
 function validate(): string | null {
@@ -77,11 +122,7 @@ async function onSubmit() {
     localStorage.setItem('token', token)
 
     // 跳转（使用 replace，不让登录页留在历史记录中）
-    // 净化 redirect：避免 redirect 指向 /auth（会话失效时可能被污染成
-    // /auth?redirect=... 嵌套），否则登录成功后又跳回登录页 → 看似登录失败
-    const rawRedirect = (route.query.redirect as string) || ''
-    const redirect = rawRedirect && !rawRedirect.startsWith('/auth') ? rawRedirect : '/board'
-    router.replace(redirect)
+    router.replace(resolveRedirect('/board'))
   } catch (err: any) {
     // 418：登录时用户不存在 → 引导切换到注册模式
     if (err?.code === ApiCode.NOT_REGISTERED && isLogin.value) {

--- a/Web/ydjz_web_v2/src/mobile/views/Auth.vue
+++ b/Web/ydjz_web_v2/src/mobile/views/Auth.vue
@@ -77,7 +77,10 @@ async function onSubmit() {
     localStorage.setItem('token', token)
 
     // 跳转（使用 replace，不让登录页留在历史记录中）
-    const redirect = (route.query.redirect as string) || '/board'
+    // 净化 redirect：避免 redirect 指向 /auth（会话失效时可能被污染成
+    // /auth?redirect=... 嵌套），否则登录成功后又跳回登录页 → 看似登录失败
+    const rawRedirect = (route.query.redirect as string) || ''
+    const redirect = rawRedirect && !rawRedirect.startsWith('/auth') ? rawRedirect : '/board'
     router.replace(redirect)
   } catch (err: any) {
     // 418：登录时用户不存在 → 引导切换到注册模式

--- a/ai/KoalaqHub/koalaq_hub/core/llm/enhanced_llm_client.py
+++ b/ai/KoalaqHub/koalaq_hub/core/llm/enhanced_llm_client.py
@@ -69,6 +69,43 @@ class EnhancedLLMClient:
     """增强版LLM客户端 - 支持动态配置和多种输出方式"""
     
     @staticmethod
+    def _extract_usage_tokens(usage, total_tokens: int, prompt_tokens: int,
+                              completion_tokens: int, reasoning_tokens: int):
+        """从一个 usage 来源（chunk.usage / choice.usage / delta.usage）提取四项 token。
+
+        统一处理两种形态：
+          - 对象形态（标准 OpenAI、moonshot 的 delta.usage、对象版 choice.usage）；
+          - 字典形态（Kimi 风格把 usage 放在 choice 里且为 dict）。
+        某一项取不到时回退到传入的当前值，行为与原先各处分散写法等价：
+        正常 usage 对象/字典一定带这些字段，取到即用；缺失才保留旧值，不会抛错。
+        reasoning_tokens 在标准 usage 中常缺省，回退尤为重要。
+
+        Args:
+            usage: 待提取的 usage 来源（对象或 dict），可能为 None。
+            total_tokens/prompt_tokens/completion_tokens/reasoning_tokens: 当前已累积值，
+                作为缺失字段的回退。
+
+        Returns:
+            (total_tokens, prompt_tokens, completion_tokens, reasoning_tokens) 四元组；
+            usage 为 None 时原样返回传入值。
+        """
+        if not usage:
+            return total_tokens, prompt_tokens, completion_tokens, reasoning_tokens
+
+        if isinstance(usage, dict):
+            getter = usage.get
+        else:
+            def getter(key, default=None):
+                return getattr(usage, key, default)
+
+        return (
+            getter("total_tokens", total_tokens),
+            getter("prompt_tokens", prompt_tokens),
+            getter("completion_tokens", completion_tokens),
+            getter("reasoning_tokens", reasoning_tokens),
+        )
+
+    @staticmethod
     def _accumulate_tool_calls(tool_calls_list: List[Dict], tool_call_delta) -> None:
         """累积流式传输的工具调用
         
@@ -78,6 +115,8 @@ class EnhancedLLMClient:
         """
         # OpenAI 协议要求 tool_call delta 必带 index，但部分兼容平台（如小米）
         # 可能下发缺失/为 None 的 index，导致 None+1 抛 TypeError。此处兜底为 0。
+        # 注意：刻意兜底为固定的 0，而非“追加到末尾”——已知平台单工具调用恒为 index=0，
+        # 若改成追加，遇到后续真带 index=0 的 arguments 分片会错位到不同槽位，反而拆散同一个工具调用。
         index = getattr(tool_call_delta, "index", None)
         if index is None:
             index = 0
@@ -213,22 +252,20 @@ class EnhancedLLMClient:
                 # 安全检查：确保chunk有choices且不为空
                 if not chunk.choices or len(chunk.choices) == 0:
                     # 处理token信息（某些chunk只包含usage信息）
-                    if chunk.usage:
-                        total_tokens = chunk.usage.total_tokens
-                        prompt_tokens = chunk.usage.prompt_tokens
-                        completion_tokens = chunk.usage.completion_tokens
-                        reasoning_tokens = getattr(chunk.usage, "reasoning_tokens", 0)
+                    total_tokens, prompt_tokens, completion_tokens, reasoning_tokens = \
+                        self._extract_usage_tokens(chunk.usage, total_tokens, prompt_tokens,
+                                                   completion_tokens, reasoning_tokens)
                     continue
-                
+
                 choice = chunk.choices[0]
                 delta = choice.delta
-                
+
                 # 处理工具调用
                 if hasattr(delta, "tool_calls") and delta.tool_calls:
                     for tool_call_delta in delta.tool_calls:
                         # 累积工具调用数据
                         self._accumulate_tool_calls(tool_calls_list, tool_call_delta)
-                
+
                 # 处理内容
                 content = delta.content
                 chunk_reasoning = getattr(delta, "reasoning_content", None)
@@ -242,38 +279,26 @@ class EnhancedLLMClient:
                     full_content += content
 
                 # 处理token信息
-                if chunk.usage:
-                    total_tokens = chunk.usage.total_tokens
-                    prompt_tokens = chunk.usage.prompt_tokens
-                    completion_tokens = chunk.usage.completion_tokens
-                    reasoning_tokens = getattr(chunk.usage, "reasoning_tokens", 0)
-                
-                # 检查其他可能的 usage 位置（如 Kimi 将 usage 放在 choice 中）
+                total_tokens, prompt_tokens, completion_tokens, reasoning_tokens = \
+                    self._extract_usage_tokens(chunk.usage, total_tokens, prompt_tokens,
+                                               completion_tokens, reasoning_tokens)
+
+                # 检查其他可能的 usage 位置（如 Kimi 将 usage 放在 choice 中，可能是 dict 或对象）
                 if hasattr(choice, 'usage') and choice.usage:
-                    # Kimi 的 usage 是字典格式
-                    if isinstance(choice.usage, dict):
-                        total_tokens = choice.usage.get('total_tokens', total_tokens)
-                        prompt_tokens = choice.usage.get('prompt_tokens', prompt_tokens)
-                        completion_tokens = choice.usage.get('completion_tokens', completion_tokens)
-                        reasoning_tokens = choice.usage.get('reasoning_tokens', reasoning_tokens)
-                    else:
-                        # 标准对象格式
-                        total_tokens = getattr(choice.usage, 'total_tokens', total_tokens)
-                        prompt_tokens = getattr(choice.usage, 'prompt_tokens', prompt_tokens)
-                        completion_tokens = getattr(choice.usage, 'completion_tokens', completion_tokens)
-                        reasoning_tokens = getattr(choice.usage, 'reasoning_tokens', reasoning_tokens)
-                
+                    total_tokens, prompt_tokens, completion_tokens, reasoning_tokens = \
+                        self._extract_usage_tokens(choice.usage, total_tokens, prompt_tokens,
+                                                   completion_tokens, reasoning_tokens)
+
                 # 特殊处理：moonshot 平台在 finish_reason="stop" 时，usage 在 delta 中
                 if self.platform == "moonshot" and hasattr(choice, "finish_reason") and choice.finish_reason == "stop":
                     if hasattr(delta, "usage") and delta.usage:
-                        total_tokens = delta.usage.total_tokens
-                        prompt_tokens = delta.usage.prompt_tokens
-                        completion_tokens = delta.usage.completion_tokens
-                        reasoning_tokens = getattr(delta.usage, "reasoning_tokens", 0)
+                        total_tokens, prompt_tokens, completion_tokens, reasoning_tokens = \
+                            self._extract_usage_tokens(delta.usage, total_tokens, prompt_tokens,
+                                                       completion_tokens, reasoning_tokens)
 
             # 将工具调用列表转换为 ToolCall 对象
             tool_calls = self._convert_tool_calls_list(tool_calls_list)
-            
+
             result = LLMResponse(
                 is_interrupted=False,
                 content=full_content, 
@@ -470,12 +495,11 @@ class EnhancedLLMClient:
                 # 部分平台（如小米 OpenAI 兼容 API）在工具调用流中会下发 choices 为空数组的
                 # usage-only chunk，直接取 [0] 会抛 list index out of range。
                 # 此处与 block()/_stream_sse() 保持一致：空 choices 时只提取 usage 后跳过。
+                # （此分支无 choice 对象，只能取 chunk.usage）
                 if not chunk.choices or len(chunk.choices) == 0:
-                    if chunk.usage:
-                        total_tokens = chunk.usage.total_tokens
-                        prompt_tokens = chunk.usage.prompt_tokens
-                        completion_tokens = chunk.usage.completion_tokens
-                        reasoning_tokens = getattr(chunk.usage, "reasoning_tokens", 0)
+                    total_tokens, prompt_tokens, completion_tokens, reasoning_tokens = \
+                        self._extract_usage_tokens(chunk.usage, total_tokens, prompt_tokens,
+                                                   completion_tokens, reasoning_tokens)
                     continue
 
                 choice = chunk.choices[0]
@@ -483,12 +507,16 @@ class EnhancedLLMClient:
 
                 # 兼容平台可能下发 delta 为空的边界 chunk（如仅含 finish_reason），
                 # 此时仍需处理本 chunk 携带的 usage，故不能直接 continue 到循环顶部。
+                # 此分支 choice 存在，故同时提取 chunk.usage 与 choice.usage（Kimi 风格），
+                # 与正常路径保持一致，避免边界 chunk 的 token 统计丢失。
                 if delta is None:
-                    if chunk.usage:
-                        total_tokens = chunk.usage.total_tokens
-                        prompt_tokens = chunk.usage.prompt_tokens
-                        completion_tokens = chunk.usage.completion_tokens
-                        reasoning_tokens = getattr(chunk.usage, "reasoning_tokens", 0)
+                    total_tokens, prompt_tokens, completion_tokens, reasoning_tokens = \
+                        self._extract_usage_tokens(chunk.usage, total_tokens, prompt_tokens,
+                                                   completion_tokens, reasoning_tokens)
+                    if hasattr(choice, 'usage') and choice.usage:
+                        total_tokens, prompt_tokens, completion_tokens, reasoning_tokens = \
+                            self._extract_usage_tokens(choice.usage, total_tokens, prompt_tokens,
+                                                       completion_tokens, reasoning_tokens)
                     continue
 
                 # 处理工具调用
@@ -527,22 +555,19 @@ class EnhancedLLMClient:
                         continue
 
                 # 处理token信息
-                if chunk.usage:
-                    total_tokens = chunk.usage.total_tokens
-                    prompt_tokens = chunk.usage.prompt_tokens
-                    completion_tokens = chunk.usage.completion_tokens
-                    reasoning_tokens = getattr(chunk.usage, "reasoning_tokens", 0)
-                
-                # 检查其他可能的 usage 位置（如 Kimi 将 usage 放在 choice 中）
+                total_tokens, prompt_tokens, completion_tokens, reasoning_tokens = \
+                    self._extract_usage_tokens(chunk.usage, total_tokens, prompt_tokens,
+                                               completion_tokens, reasoning_tokens)
+
+                # 检查其他可能的 usage 位置（如 Kimi 将 usage 放在 choice 中，可能是 dict 或对象）
                 if hasattr(choice, 'usage') and choice.usage:
-                    total_tokens = choice.usage.get('total_tokens', total_tokens)
-                    prompt_tokens = choice.usage.get('prompt_tokens', prompt_tokens)
-                    completion_tokens = choice.usage.get('completion_tokens', completion_tokens)
-                    reasoning_tokens = choice.usage.get('reasoning_tokens', reasoning_tokens)
-                   
+                    total_tokens, prompt_tokens, completion_tokens, reasoning_tokens = \
+                        self._extract_usage_tokens(choice.usage, total_tokens, prompt_tokens,
+                                                   completion_tokens, reasoning_tokens)
+
             # 将工具调用列表转换为 ToolCall 对象
             tool_calls = self._convert_tool_calls_list(tool_calls_list)
-            
+
             return LLMResponse(
                 is_interrupted=is_interrupted,
                 content=full_content, 

--- a/ai/KoalaqHub/koalaq_hub/core/llm/enhanced_llm_client.py
+++ b/ai/KoalaqHub/koalaq_hub/core/llm/enhanced_llm_client.py
@@ -76,8 +76,12 @@ class EnhancedLLMClient:
             tool_calls_list: 工具调用列表
             tool_call_delta: 流式传输的工具调用片段
         """
-        index = tool_call_delta.index
-        
+        # OpenAI 协议要求 tool_call delta 必带 index，但部分兼容平台（如小米）
+        # 可能下发缺失/为 None 的 index，导致 None+1 抛 TypeError。此处兜底为 0。
+        index = getattr(tool_call_delta, "index", None)
+        if index is None:
+            index = 0
+
         # 根据 index 扩充列表
         if len(tool_calls_list) < (index + 1):
             tool_calls_list.extend([{}] * (index + 1 - len(tool_calls_list)))
@@ -461,18 +465,39 @@ class EnhancedLLMClient:
                     # 主动关闭stream连接，真正停止服务器端生成
                     await safe_close_stream(stream)
                     break  # 中断循环，停止token消耗
-            
+
+                # 安全检查：确保chunk有choices且不为空
+                # 部分平台（如小米 OpenAI 兼容 API）在工具调用流中会下发 choices 为空数组的
+                # usage-only chunk，直接取 [0] 会抛 list index out of range。
+                # 此处与 block()/_stream_sse() 保持一致：空 choices 时只提取 usage 后跳过。
+                if not chunk.choices or len(chunk.choices) == 0:
+                    if chunk.usage:
+                        total_tokens = chunk.usage.total_tokens
+                        prompt_tokens = chunk.usage.prompt_tokens
+                        completion_tokens = chunk.usage.completion_tokens
+                        reasoning_tokens = getattr(chunk.usage, "reasoning_tokens", 0)
+                    continue
 
                 choice = chunk.choices[0]
                 delta = choice.delta
-                
+
+                # 兼容平台可能下发 delta 为空的边界 chunk（如仅含 finish_reason），
+                # 此时仍需处理本 chunk 携带的 usage，故不能直接 continue 到循环顶部。
+                if delta is None:
+                    if chunk.usage:
+                        total_tokens = chunk.usage.total_tokens
+                        prompt_tokens = chunk.usage.prompt_tokens
+                        completion_tokens = chunk.usage.completion_tokens
+                        reasoning_tokens = getattr(chunk.usage, "reasoning_tokens", 0)
+                    continue
+
                 # 处理工具调用
                 if hasattr(delta, "tool_calls") and delta.tool_calls:
                     for tool_call_delta in delta.tool_calls:
                         self._accumulate_tool_calls(tool_calls_list, tool_call_delta)
-                
+
                 # 处理内容
-                content = delta.content
+                content = getattr(delta, "content", None)
                 chunk_reasoning = getattr(delta, "reasoning_content", None)
 
                 # 发送思考内容(如果模型支持) 子agent模式不发送


### PR DESCRIPTION
## 2.7.1 Bug 修复

### 1. AI · 小米 API 接入兼容（list index out of range）
小米 OpenAI 兼容接口在工具调用流尾部会下发 `choices` 为空数组的 usage-only chunk，`_stream_websocket` 在取 `chunk.choices[0]` 前缺少空 choices 守卫（`block()` / `_stream_sse()` 本就有），导致 `IndexError: list index out of range`，AI 助手报「WebSocket流式请求失败 / 处理消息时出现错误」。

- 补空 choices 守卫，与 `block()` / `_stream_sse()` 对齐：空则仅提取 usage 后跳过
- 兜底 `delta` 为 None 的边界 chunk、`tool_call` delta 缺失 `index` 的情况
- 新增分支仅在异常结构时命中，OpenAI / 智谱等标准供应商行为不变
- 已用真实小米 API（`mimo-v2.5-pro`）抓包坐实根因（尾部 `choices:[]` chunk），并以修复后整服务端到端验证三轮工具调用全程零报错

### 2. Web · 恢复路由首屏鉴权竞态（页面不可操作、需刷新+重登）
重新打开网页恢复上次路由时，无有效会话仍渲染陈旧页面、等接口 401 才被动跳转；首屏并发 401 把 `/auth?redirect=...` 层层嵌套成畸形 URL，登录成功后又跳回登录页。

- 双端路由新增 `beforeEach` 前置鉴权守卫：无 token 直接干净跳登录页（带原始 redirect）
- 移动端 `onUnauthorized` 补「已在 /auth 页不重复跳转」守卫，杜绝 redirect 嵌套
- 双端登录成功净化 redirect，避免跳回登录页

### 3. chore
- `.gitignore` 忽略 `.understand-anything/` 本地知识图谱产物

> 仅 Web 前端 + AI 模块改动，不涉及 Java 后端。
